### PR TITLE
chore(ci): enable GPG commit signing in docs-release

### DIFF
--- a/.github/workflows/code-maven_java-release.yml
+++ b/.github/workflows/code-maven_java-release.yml
@@ -140,8 +140,12 @@ jobs:
           EOT
 
           echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
+          FPR=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')
           git config user.name "InditexTech CI"
           git config user.email "oso@inditex.com"
+          git config --global gpg.program gpg
+          git config --global user.signingkey "$FPR"
+          git config --global commit.gpgsign true
 
       - name: Update CHANGELOG.md
         id: update-changelog

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -98,8 +98,13 @@ jobs:
           EOT
 
           echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
+          FPR=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')
+
           git config user.name "InditexTech CI"
           git config user.email "oso@inditex.com"
+          git config --global gpg.program gpg
+          git config --global user.signingkey "$FPR"
+          git config --global commit.gpgsign true
 
       - name: Docker / Execute Kroki server
         run: |


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Other... Please describe: CI/workflow maintenance to enable GPG commit signing in docs and code release processes.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The docs release workflow imports a GPG key but does not ensure commit signing is configured globally for Git in the runner, so commits may be created unsigned depending on Git configuration. The code release workflow also imports the key but creates the CHANGELOG commit without enabling GPG signing.

Issue Number: N/A

## What is the new behavior?

The docs and code release workflows now configure Git global GPG signing by resolving the imported secret key fingerprint and setting:
- `gpg.program`
- `user.signingkey`
- `commit.gpgsign=true`

As a result, commits created in the docs release job and the code release CHANGELOG commit are signed by default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Scope intentionally kept minimal: only workflow configuration in docs release and code release jobs, no application/runtime code changes.
