### PR TITLE
chore(ci): update GPG signing to non-interactive pinentry loopback

### DIFF
--- a/.github/workflows/code-maven_java-release.yml
+++ b/.github/workflows/code-maven_java-release.yml
@@ -129,23 +129,35 @@ jobs:
         if: contains(env.RELEASE_LABELS, 'release-type/major')
         run: echo "RELEASE_VERSION=major" >> "$GITHUB_ENV"
 
-      - name: Prepare committer information and set GPG key
+      - name: Prepare committer information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCM_COMMITTER_PGP_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.CI_GPG_SECRET_KEY_PASSWORD }}
         run: |
           git config --global credential.helper store
           cat <<EOT >> ~/.git-credentials
           https://ci-user:$GITHUB_TOKEN@github.com
           EOT
 
-          echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
-          FPR=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')
-          git config user.name "InditexTech CI"
+          # GPG: non-interactive signing setup
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          printf 'allow-loopback-pinentry\nallow-preset-passphrase\n' > ~/.gnupg/gpg-agent.conf
+          printf 'use-agent\npinentry-mode loopback\n' > ~/.gnupg/gpg.conf
+          gpgconf --kill gpg-agent || true
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_DATA=$(gpg --list-secret-keys --with-colons)
+          echo "$KEY_DATA" | awk -F: '/^grp:/ {print $10}' | while read -r GRIP; do
+            /usr/lib/gnupg/gpg-preset-passphrase --preset "$GRIP" <<< "$GPG_PASSPHRASE"
+          done
+
+          # Git: identity and signing
+          FPR=$(echo "$KEY_DATA" | awk -F: '/^fpr:/ {print $10; exit}')
+          git config user.name "srvcosoitxtech"
           git config user.email "oso@inditex.com"
-          git config --global gpg.program gpg
-          git config --global user.signingkey "$FPR"
-          git config --global commit.gpgsign true
+          git config user.signingkey "$FPR"
+          git config commit.gpgsign true
+          git config tag.gpgsign true
 
       - name: Update CHANGELOG.md
         id: update-changelog

--- a/.github/workflows/docs-build_snapshot.yml
+++ b/.github/workflows/docs-build_snapshot.yml
@@ -88,19 +88,35 @@ jobs:
         with:
           tool_versions: ${{ env.TOOL_VERSIONS }}
 
-      - name: Configure Git
+      - name: Prepare committer information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCM_COMMITTER_PGP_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.CI_GPG_SECRET_KEY_PASSWORD }}
         run: |
           git config --global credential.helper store
           cat <<EOT >> ~/.git-credentials
           https://ci-user:$GITHUB_TOKEN@github.com
           EOT
 
-          echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
-          git config user.name "InditexTech CI"
+          # GPG: non-interactive signing setup
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          printf 'allow-loopback-pinentry\nallow-preset-passphrase\n' > ~/.gnupg/gpg-agent.conf
+          printf 'use-agent\npinentry-mode loopback\n' > ~/.gnupg/gpg.conf
+          gpgconf --kill gpg-agent || true
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_DATA=$(gpg --list-secret-keys --with-colons)
+          echo "$KEY_DATA" | awk -F: '/^grp:/ {print $10}' | while read -r GRIP; do
+            /usr/lib/gnupg/gpg-preset-passphrase --preset "$GRIP" <<< "$GPG_PASSPHRASE"
+          done
+
+          # Git: identity and signing
+          FPR=$(echo "$KEY_DATA" | awk -F: '/^fpr:/ {print $10; exit}')
+          git config user.name "srvcosoitxtech"
           git config user.email "oso@inditex.com"
+          git config user.signingkey "$FPR"
+          git config commit.gpgsign true
+          git config tag.gpgsign true
 
       - name: Docker / Execute Kroki server
         run: |

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -82,19 +82,35 @@ jobs:
       with:
         tool_versions: ${{ env.TOOL_VERSIONS }}
 
-    - name: Configure Git
+    - name: Prepare committer information
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SCM_COMMITTER_PGP_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+        GPG_PRIVATE_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+        GPG_PASSPHRASE: ${{ secrets.CI_GPG_SECRET_KEY_PASSWORD }}
       run: |
         git config --global credential.helper store
         cat <<EOT >> ~/.git-credentials
         https://ci-user:$GITHUB_TOKEN@github.com
         EOT
 
-        echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
-        git config user.name "InditexTech CI"
+        # GPG: non-interactive signing setup
+        mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+        printf 'allow-loopback-pinentry\nallow-preset-passphrase\n' > ~/.gnupg/gpg-agent.conf
+        printf 'use-agent\npinentry-mode loopback\n' > ~/.gnupg/gpg.conf
+        gpgconf --kill gpg-agent || true
+        echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        KEY_DATA=$(gpg --list-secret-keys --with-colons)
+        echo "$KEY_DATA" | awk -F: '/^grp:/ {print $10}' | while read -r GRIP; do
+          /usr/lib/gnupg/gpg-preset-passphrase --preset "$GRIP" <<< "$GPG_PASSPHRASE"
+        done
+
+        # Git: identity and signing
+        FPR=$(echo "$KEY_DATA" | awk -F: '/^fpr:/ {print $10; exit}')
+        git config user.name "srvcosoitxtech"
         git config user.email "oso@inditex.com"
+        git config user.signingkey "$FPR"
+        git config commit.gpgsign true
+        git config tag.gpgsign true
 
     - name: Docker / Execute Kroki server
       run: |

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -87,24 +87,35 @@ jobs:
         with:
           tool_versions: ${{ env.TOOL_VERSIONS }}
 
-      - name: Prepare committer information and set GPG key
+      - name: Prepare committer information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCM_COMMITTER_PGP_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.CI_GPG_SECRET_KEY_PASSWORD }}
         run: |
           git config --global credential.helper store
           cat <<EOT >> ~/.git-credentials
           https://ci-user:$GITHUB_TOKEN@github.com
           EOT
 
-          echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
-          FPR=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')
+          # GPG: non-interactive signing setup
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          printf 'allow-loopback-pinentry\nallow-preset-passphrase\n' > ~/.gnupg/gpg-agent.conf
+          printf 'use-agent\npinentry-mode loopback\n' > ~/.gnupg/gpg.conf
+          gpgconf --kill gpg-agent || true
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_DATA=$(gpg --list-secret-keys --with-colons)
+          echo "$KEY_DATA" | awk -F: '/^grp:/ {print $10}' | while read -r GRIP; do
+            /usr/lib/gnupg/gpg-preset-passphrase --preset "$GRIP" <<< "$GPG_PASSPHRASE"
+          done
 
-          git config user.name "InditexTech CI"
+          # Git: identity and signing
+          FPR=$(echo "$KEY_DATA" | awk -F: '/^fpr:/ {print $10; exit}')
+          git config user.name "srvcosoitxtech"
           git config user.email "oso@inditex.com"
-          git config --global gpg.program gpg
-          git config --global user.signingkey "$FPR"
-          git config --global commit.gpgsign true
+          git config user.signingkey "$FPR"
+          git config commit.gpgsign true
+          git config tag.gpgsign true
 
       - name: Docker / Execute Kroki server
         run: |

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -52,19 +52,35 @@ jobs:
         with:
           tool_versions: ${{ env.TOOL_VERSIONS }}
 
-      - name: Configure Git
+      - name: Prepare committer information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCM_COMMITTER_PGP_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.CI_GPG_SECRET_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.CI_GPG_SECRET_KEY_PASSWORD }}
         run: |
           git config --global credential.helper store
           cat <<EOT >> ~/.git-credentials
           https://ci-user:$GITHUB_TOKEN@github.com
           EOT
 
-          echo "$SCM_COMMITTER_PGP_KEY" | gpg --batch --import
-          git config user.name "InditexTech CI"
+          # GPG: non-interactive signing setup
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          printf 'allow-loopback-pinentry\nallow-preset-passphrase\n' > ~/.gnupg/gpg-agent.conf
+          printf 'use-agent\npinentry-mode loopback\n' > ~/.gnupg/gpg.conf
+          gpgconf --kill gpg-agent || true
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_DATA=$(gpg --list-secret-keys --with-colons)
+          echo "$KEY_DATA" | awk -F: '/^grp:/ {print $10}' | while read -r GRIP; do
+            /usr/lib/gnupg/gpg-preset-passphrase --preset "$GRIP" <<< "$GPG_PASSPHRASE"
+          done
+
+          # Git: identity and signing
+          FPR=$(echo "$KEY_DATA" | awk -F: '/^fpr:/ {print $10; exit}')
+          git config user.name "srvcosoitxtech"
           git config user.email "oso@inditex.com"
+          git config user.signingkey "$FPR"
+          git config commit.gpgsign true
+          git config tag.gpgsign true
 
       - name: Docker / Execute Kroki server
         run: |


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Other... Please describe:

CI workflow configuration update — unifies and hardens GPG commit signing across all workflows.

## What is the current behavior?

Issue Number: #59

Only 2 of 5 workflows (`docs-release.yml`, `code-maven_java-release.yml`) have commit signing enabled. The other 3 (`docs-build_snapshot.yml`, `docs-publish.yml`, `docs-verify.yml`) import the GPG key but never configure signing. Additionally, the existing setup lacks `gpg-agent` configuration for loopback pinentry and passphrase preset, which can cause signing failures in non-interactive CI environments.

## What is the new behavior?

- Unifies GPG commit signing configuration across all 5 workflow files
- Adds non-interactive pinentry loopback and passphrase preset via gpg-agent
- Enables `commit.gpgsign` and `tag.gpgsign` in all workflows (previously only 2 of 5)
- Changes committer name from `InditexTech CI` to `srvcosoitxtech`
- Renames env var `SCM_COMMITTER_PGP_KEY` to `GPG_PRIVATE_KEY` for clarity
- Removes unnecessary `git config --global gpg.program gpg`
- Uses local git config (no `--global`) for signing keys

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Closes #59