### PR TITLE
fix(ci): add SCM server credentials for maven-release-plugin push

### DIFF
--- a/.github/workflows/code-maven_java-release.yml
+++ b/.github/workflows/code-maven_java-release.yml
@@ -194,6 +194,11 @@ jobs:
                 <id>gpg.passphrase</id>
                 <passphrase>${{ secrets.CI_GPG_SECRET_KEY_PASSWORD }}</passphrase>
               </server>
+              <server>
+                <id>inditextech-scm-github</id>
+                <username>x-access-token</username>
+                <password>${{ steps.app-token.outputs.token }}</password>
+              </server>
             </servers>
           </settings>
           EOF


### PR DESCRIPTION
## Summary

The release workflow fails during `release:prepare` because the maven-release-plugin cannot authenticate git push operations.

- Add `inditextech-scm-github` server entry to the inline `~/.m2/settings.xml` with the GitHub App token credentials
- This is required because the plugin resolves `project.scm.id` from the POM to find credentials for SCM operations (`scm-commit-release`, `scm:add@sync-karate-version`)

## Root cause

The `-DdeveloperConnection` override alone is insufficient — the maven-scm provider still looks up the server by `project.scm.id` in settings.xml for authentication. Without it:
```
[WARNING] No server with id 'inditextech-scm-github' found in Maven settings
[ERROR] fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## Reference

- Failed run: https://github.com/InditexTech/karatetools-oss/actions/runs/28229186301/job/83628462516
- Original port: InditexTech/scs-outbox@12a447a7ed06bd807f9f2331bed65939a662f105

Fixes #83