### PR TITLE
fix(deps): apply in-range npm audit fixes to CI/build lockfiles

### DIFF
--- a/.github/actions/config-resolver/package-lock.json
+++ b/.github/actions/config-resolver/package-lock.json
@@ -67,7 +67,7 @@
         },
         "node_modules/@babel/compat-data": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
             "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
@@ -77,7 +77,7 @@
         },
         "node_modules/@babel/core": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/core/-/core-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
@@ -108,7 +108,7 @@
         },
         "node_modules/@babel/core/node_modules/@babel/code-frame": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
             "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
@@ -138,7 +138,7 @@
         },
         "node_modules/@babel/generator": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/generator/-/generator-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
             "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
             "license": "MIT",
@@ -155,7 +155,7 @@
         },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
             "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
@@ -172,7 +172,7 @@
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
@@ -182,7 +182,7 @@
         },
         "node_modules/@babel/helper-globals": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
             "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
@@ -192,7 +192,7 @@
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
             "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
@@ -206,7 +206,7 @@
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
             "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
@@ -233,7 +233,7 @@
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
             "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
@@ -243,7 +243,7 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
@@ -253,7 +253,7 @@
         },
         "node_modules/@babel/helper-validator-option": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
             "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
@@ -263,7 +263,7 @@
         },
         "node_modules/@babel/helpers": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helpers/-/helpers-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
             "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
@@ -363,7 +363,7 @@
         },
         "node_modules/@babel/parser": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/parser/-/parser-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
             "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "license": "MIT",
@@ -571,7 +571,7 @@
         },
         "node_modules/@babel/template": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/template/-/template-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
             "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
@@ -586,7 +586,7 @@
         },
         "node_modules/@babel/template/node_modules/@babel/code-frame": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
             "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
@@ -601,7 +601,7 @@
         },
         "node_modules/@babel/traverse": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/traverse/-/traverse-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
             "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
             "license": "MIT",
@@ -620,7 +620,7 @@
         },
         "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
             "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
@@ -635,7 +635,7 @@
         },
         "node_modules/@babel/types": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/types/-/types-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
             "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "license": "MIT",
@@ -700,7 +700,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
             "version": "3.15.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
             "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
@@ -769,7 +769,7 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
             "version": "3.15.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
             "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
@@ -1028,7 +1028,7 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "license": "MIT",
@@ -1039,7 +1039,7 @@
         },
         "node_modules/@jridgewell/remapping": {
             "version": "2.3.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "dev": true,
             "license": "MIT",
@@ -1050,7 +1050,7 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "license": "MIT",
@@ -1060,14 +1060,14 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
@@ -1289,7 +1289,7 @@
         },
         "node_modules/ajv": {
             "version": "6.15.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-6.15.0.tgz",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
             "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
@@ -1611,7 +1611,7 @@
         },
         "node_modules/baseline-browser-mapping": {
             "version": "2.11.19",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
             "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
             "dev": true,
             "license": "Apache-2.0",
@@ -1624,7 +1624,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.18",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
             "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "license": "MIT",
             "dependencies": {
@@ -1652,7 +1652,7 @@
         },
         "node_modules/browserslist": {
             "version": "4.28.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/browserslist/-/browserslist-4.28.8.tgz",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
             "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "dev": true,
             "funding": [
@@ -1721,7 +1721,7 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "license": "MIT",
@@ -1753,7 +1753,7 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001810",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
             "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
@@ -1970,7 +1970,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
@@ -2165,7 +2165,7 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dev": true,
             "license": "MIT",
@@ -2180,7 +2180,7 @@
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.415",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
             "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
             "dev": true,
             "license": "ISC"
@@ -2236,7 +2236,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
             "license": "MIT",
@@ -2246,7 +2246,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
             "license": "MIT",
@@ -2256,7 +2256,7 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
             "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "license": "MIT",
@@ -2269,7 +2269,7 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dev": true,
             "license": "MIT",
@@ -2285,7 +2285,7 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "license": "MIT",
@@ -2450,7 +2450,7 @@
         },
         "node_modules/eslint/node_modules/js-yaml": {
             "version": "3.15.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
             "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
@@ -2777,7 +2777,7 @@
         },
         "node_modules/fast-uri": {
             "version": "3.1.6",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/fast-uri/-/fast-uri-3.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
             "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "dev": true,
             "funding": [
@@ -2854,7 +2854,7 @@
         },
         "node_modules/flatted": {
             "version": "3.4.4",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/flatted/-/flatted-3.4.4.tgz",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
             "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true,
             "license": "ISC"
@@ -2870,7 +2870,7 @@
         },
         "node_modules/form-data": {
             "version": "3.0.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/form-data/-/form-data-3.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
             "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
             "dev": true,
             "license": "MIT",
@@ -2951,7 +2951,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "license": "MIT",
@@ -2985,7 +2985,7 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
             "license": "MIT",
@@ -3070,7 +3070,7 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
             "license": "MIT",
@@ -3105,7 +3105,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
@@ -3118,7 +3118,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "license": "MIT",
@@ -3197,7 +3197,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.4",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/hasown/-/hasown-2.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
@@ -4209,7 +4209,7 @@
         },
         "node_modules/js-yaml": {
             "version": "4.3.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-4.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
             "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
@@ -4404,7 +4404,7 @@
         },
         "node_modules/lodash": {
             "version": "4.18.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lodash/-/lodash-4.18.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
@@ -4427,7 +4427,7 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lru-cache/-/lru-cache-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "license": "ISC",
@@ -4482,7 +4482,7 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true,
             "license": "MIT",
@@ -4541,7 +4541,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
@@ -4636,7 +4636,7 @@
         },
         "node_modules/node-releases": {
             "version": "2.0.53",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/node-releases/-/node-releases-2.0.53.tgz",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
             "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
             "dev": true,
             "license": "MIT",
@@ -4949,7 +4949,7 @@
         },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
@@ -5374,7 +5374,7 @@
         },
         "node_modules/sane/node_modules/cross-spawn": {
             "version": "6.0.6",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-6.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
             "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
             "dev": true,
             "license": "MIT",
@@ -6159,7 +6159,7 @@
         },
         "node_modules/table/node_modules/ajv": {
             "version": "8.20.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-8.20.0.tgz",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
@@ -6358,7 +6358,7 @@
         },
         "node_modules/undici": {
             "version": "5.29.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/undici/-/undici-5.29.0.tgz",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
             "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
             "license": "MIT",
             "dependencies": {
@@ -6457,7 +6457,7 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.3.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
             "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "dev": true,
             "funding": [
@@ -6702,7 +6702,7 @@
         },
         "node_modules/ws": {
             "version": "7.5.13",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ws/-/ws-7.5.13.tgz",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
             "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "dev": true,
             "license": "MIT",
@@ -6742,7 +6742,7 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
@@ -6826,13 +6826,13 @@
         },
         "@babel/compat-data": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
             "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true
         },
         "@babel/core": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/core/-/core-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "requires": {
@@ -6855,7 +6855,7 @@
             "dependencies": {
                 "@babel/code-frame": {
                     "version": "7.29.7",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
                     "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
                     "dev": true,
                     "requires": {
@@ -6880,7 +6880,7 @@
         },
         "@babel/generator": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/generator/-/generator-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
             "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
             "requires": {
@@ -6893,7 +6893,7 @@
         },
         "@babel/helper-compilation-targets": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
             "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "requires": {
@@ -6906,7 +6906,7 @@
             "dependencies": {
                 "semver": {
                     "version": "6.3.1",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/semver/-/semver-6.3.1.tgz",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
                     "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "dev": true
                 }
@@ -6914,13 +6914,13 @@
         },
         "@babel/helper-globals": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
             "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true
         },
         "@babel/helper-module-imports": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
             "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "requires": {
@@ -6930,7 +6930,7 @@
         },
         "@babel/helper-module-transforms": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
             "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "requires": {
@@ -6947,25 +6947,25 @@
         },
         "@babel/helper-string-parser": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
             "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true
         },
         "@babel/helper-validator-option": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
             "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true
         },
         "@babel/helpers": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helpers/-/helpers-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
             "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "requires": {
@@ -7045,7 +7045,7 @@
         },
         "@babel/parser": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/parser/-/parser-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
             "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "requires": {
@@ -7189,7 +7189,7 @@
         },
         "@babel/template": {
             "version": "7.29.7",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/template/-/template-7.29.7.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
             "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "requires": {
@@ -7200,7 +7200,7 @@
             "dependencies": {
                 "@babel/code-frame": {
                     "version": "7.29.7",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
                     "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
                     "dev": true,
                     "requires": {
@@ -7213,7 +7213,7 @@
         },
         "@babel/traverse": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/traverse/-/traverse-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
             "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
             "requires": {
@@ -7228,7 +7228,7 @@
             "dependencies": {
                 "@babel/code-frame": {
                     "version": "7.29.7",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
                     "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
                     "dev": true,
                     "requires": {
@@ -7241,7 +7241,7 @@
         },
         "@babel/types": {
             "version": "7.29.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/types/-/types-7.29.8.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
             "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "requires": {
@@ -7293,7 +7293,7 @@
                 },
                 "js-yaml": {
                     "version": "3.15.1",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
                     "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
                     "dev": true,
                     "requires": {
@@ -7349,7 +7349,7 @@
                 },
                 "js-yaml": {
                     "version": "3.15.1",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
                     "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
                     "dev": true,
                     "requires": {
@@ -7565,7 +7565,7 @@
         },
         "@jridgewell/gen-mapping": {
             "version": "0.3.13",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "requires": {
@@ -7575,7 +7575,7 @@
         },
         "@jridgewell/remapping": {
             "version": "2.3.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "dev": true,
             "requires": {
@@ -7585,19 +7585,19 @@
         },
         "@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.31",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "requires": {
@@ -7797,7 +7797,7 @@
         },
         "ajv": {
             "version": "6.15.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-6.15.0.tgz",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
             "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "requires": {
@@ -8036,13 +8036,13 @@
         },
         "baseline-browser-mapping": {
             "version": "2.11.19",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
             "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
             "dev": true
         },
         "brace-expansion": {
             "version": "1.1.18",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
             "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "requires": {
                 "balanced-match": "^1.0.0",
@@ -8066,7 +8066,7 @@
         },
         "browserslist": {
             "version": "4.28.8",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/browserslist/-/browserslist-4.28.8.tgz",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
             "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "dev": true,
             "requires": {
@@ -8111,7 +8111,7 @@
         },
         "call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "requires": {
@@ -8133,7 +8133,7 @@
         },
         "caniuse-lite": {
             "version": "1.0.30001810",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
             "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true
         },
@@ -8294,7 +8294,7 @@
         },
         "cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "requires": {
@@ -8441,7 +8441,7 @@
         },
         "dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dev": true,
             "requires": {
@@ -8452,7 +8452,7 @@
         },
         "electron-to-chromium": {
             "version": "1.5.415",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
             "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
             "dev": true
         },
@@ -8498,19 +8498,19 @@
         },
         "es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true
         },
         "es-errors": {
             "version": "1.3.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true
         },
         "es-object-atoms": {
             "version": "1.1.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
             "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "requires": {
@@ -8519,7 +8519,7 @@
         },
         "es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dev": true,
             "requires": {
@@ -8531,7 +8531,7 @@
         },
         "escalade": {
             "version": "3.2.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true
         },
@@ -8620,7 +8620,7 @@
                 },
                 "js-yaml": {
                     "version": "3.15.1",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
                     "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
                     "dev": true,
                     "requires": {
@@ -8915,7 +8915,7 @@
         },
         "fast-uri": {
             "version": "3.1.6",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/fast-uri/-/fast-uri-3.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
             "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "dev": true
         },
@@ -8969,7 +8969,7 @@
         },
         "flatted": {
             "version": "3.4.4",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/flatted/-/flatted-3.4.4.tgz",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
             "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true
         },
@@ -8981,7 +8981,7 @@
         },
         "form-data": {
             "version": "3.0.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/form-data/-/form-data-3.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
             "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
             "dev": true,
             "requires": {
@@ -9039,7 +9039,7 @@
         },
         "get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "requires": {
@@ -9063,7 +9063,7 @@
         },
         "get-proto": {
             "version": "1.0.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
             "requires": {
@@ -9119,7 +9119,7 @@
         },
         "gopd": {
             "version": "1.2.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true
         },
@@ -9144,13 +9144,13 @@
         },
         "has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true
         },
         "has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "requires": {
@@ -9211,7 +9211,7 @@
         },
         "hasown": {
             "version": "2.0.4",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/hasown/-/hasown-2.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "requires": {
@@ -9989,7 +9989,7 @@
         },
         "js-yaml": {
             "version": "4.3.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-4.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
             "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "requires": {
                 "argparse": "^2.0.1"
@@ -10128,7 +10128,7 @@
         },
         "lodash": {
             "version": "4.18.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lodash/-/lodash-4.18.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true
         },
@@ -10150,7 +10150,7 @@
         },
         "lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lru-cache/-/lru-cache-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "requires": {
@@ -10192,7 +10192,7 @@
         },
         "math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true
         },
@@ -10235,7 +10235,7 @@
         },
         "minimatch": {
             "version": "3.1.5",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -10317,7 +10317,7 @@
         },
         "node-releases": {
             "version": "2.0.53",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/node-releases/-/node-releases-2.0.53.tgz",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
             "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
             "dev": true
         },
@@ -10552,7 +10552,7 @@
         },
         "picomatch": {
             "version": "2.3.2",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true
         },
@@ -10876,7 +10876,7 @@
                 },
                 "cross-spawn": {
                     "version": "6.0.6",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-6.0.6.tgz",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
                     "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
                     "dev": true,
                     "requires": {
@@ -11499,7 +11499,7 @@
             "dependencies": {
                 "ajv": {
                     "version": "8.20.0",
-                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-8.20.0.tgz",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
                     "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
                     "dev": true,
                     "requires": {
@@ -11655,7 +11655,7 @@
         },
         "undici": {
             "version": "5.29.0",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/undici/-/undici-5.29.0.tgz",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
             "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
             "requires": {
                 "@fastify/busboy": "^2.0.0"
@@ -11735,7 +11735,7 @@
         },
         "update-browserslist-db": {
             "version": "1.3.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
             "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "dev": true,
             "requires": {
@@ -11926,7 +11926,7 @@
         },
         "ws": {
             "version": "7.5.13",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ws/-/ws-7.5.13.tgz",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
             "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "dev": true,
             "requires": {}
@@ -11951,7 +11951,7 @@
         },
         "yallist": {
             "version": "3.1.1",
-            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },

--- a/.github/actions/config-resolver/package-lock.json
+++ b/.github/actions/config-resolver/package-lock.json
@@ -56,19 +56,6 @@
             "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
             "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -79,30 +66,32 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-            "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-            "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.0",
-                "@babel/generator": "^7.26.0",
-                "@babel/helper-compilation-targets": "^7.25.9",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.0",
-                "@babel/parser": "^7.26.0",
-                "@babel/template": "^7.25.9",
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.26.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -118,14 +107,15 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -147,15 +137,16 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.2",
-                "@babel/types": "^7.26.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -163,13 +154,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-            "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.25.9",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -180,35 +172,48 @@
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -227,40 +232,44 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -353,12 +362,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.0"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -560,82 +570,78 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template/node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/generator": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.25.9",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.8",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.8",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/types": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -693,10 +699,11 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.15.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -761,10 +768,11 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.15.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -1019,48 +1027,50 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.13",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "dev": true
+            "version": "1.5.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1278,10 +1288,11 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1598,10 +1609,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.11.19",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+            "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.18",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1626,9 +1651,9 @@
             "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.24.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-            "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+            "version": "4.28.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/browserslist/-/browserslist-4.28.8.tgz",
+            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "dev": true,
             "funding": [
                 {
@@ -1644,11 +1669,13 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001669",
-                "electron-to-chromium": "^1.5.41",
-                "node-releases": "^2.0.18",
-                "update-browserslist-db": "^1.1.1"
+                "baseline-browser-mapping": "^2.11.12",
+                "caniuse-lite": "^1.0.30001809",
+                "electron-to-chromium": "^1.5.402",
+                "node-releases": "^2.0.53",
+                "update-browserslist-db": "^1.3.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1692,6 +1719,20 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1711,9 +1752,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001677",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-            "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+            "version": "1.0.30001810",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
                 {
@@ -1728,7 +1769,8 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "license": "CC-BY-4.0"
         },
         "node_modules/capture-exit": {
             "version": "2.0.0",
@@ -1927,10 +1969,11 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2120,11 +2163,27 @@
                 "dot-object": "bin/dot-object"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.50",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
-            "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
-            "dev": true
+            "version": "1.5.415",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+            "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/emittery": {
             "version": "0.7.2",
@@ -2175,11 +2234,61 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -2340,10 +2449,11 @@
             }
         },
         "node_modules/eslint/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.15.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -2666,10 +2776,21 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-            "dev": true
+            "version": "3.1.6",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
@@ -2732,10 +2853,11 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-            "dev": true
+            "version": "3.4.4",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/for-in": {
             "version": "1.0.2",
@@ -2747,14 +2869,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
-            "integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
+            "version": "3.0.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/form-data/-/form-data-3.0.5.tgz",
+            "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -2824,6 +2949,31 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2831,6 +2981,20 @@
             "dev": true,
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -2904,6 +3068,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2924,6 +3101,35 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-value": {
@@ -2990,10 +3196,11 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -4001,9 +4208,20 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.3.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -4185,10 +4403,11 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "version": "4.18.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
@@ -4208,9 +4427,10 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -4258,6 +4478,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/merge-stream": {
@@ -4310,9 +4540,10 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -4404,10 +4635,14 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-            "dev": true
+            "version": "2.0.53",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/node-releases/-/node-releases-2.0.53.tgz",
+            "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -4713,10 +4948,11 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -5137,10 +5373,11 @@
             }
         },
         "node_modules/sane/node_modules/cross-spawn": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "version": "6.0.6",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-6.0.6.tgz",
+            "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -5921,10 +6158,11 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.20.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6119,9 +6357,10 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.28.4",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+            "version": "5.29.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },
@@ -6217,9 +6456,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-            "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+            "version": "1.3.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "dev": true,
             "funding": [
                 {
@@ -6235,9 +6474,10 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
-                "picocolors": "^1.1.0"
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -6461,10 +6701,11 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "7.5.13",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -6501,9 +6742,10 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "15.4.1",
@@ -6573,16 +6815,6 @@
             "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
             "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
-        "@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "requires": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
         "@babel/code-frame": {
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -6593,27 +6825,27 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-            "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-            "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "requires": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.0",
-                "@babel/generator": "^7.26.0",
-                "@babel/helper-compilation-targets": "^7.25.9",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.0",
-                "@babel/parser": "^7.26.0",
-                "@babel/template": "^7.25.9",
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.26.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -6622,14 +6854,14 @@
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.26.2",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-                    "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+                    "version": "7.29.7",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+                    "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
                     "dev": true,
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.25.9",
+                        "@babel/helper-validator-identifier": "^7.29.7",
                         "js-tokens": "^4.0.0",
-                        "picocolors": "^1.0.0"
+                        "picocolors": "^1.1.1"
                     }
                 },
                 "convert-source-map": {
@@ -6647,26 +6879,26 @@
             }
         },
         "@babel/generator": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.26.2",
-                "@babel/types": "^7.26.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-            "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.25.9",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -6674,31 +6906,37 @@
             "dependencies": {
                 "semver": {
                     "version": "6.3.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/semver/-/semver-6.3.1.tgz",
                     "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "dev": true
                 }
             }
         },
+        "@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true
+        },
         "@babel/helper-module-imports": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -6708,31 +6946,31 @@
             "dev": true
         },
         "@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true
         },
         "@babel/helper-validator-option": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             }
         },
         "@babel/highlight": {
@@ -6806,12 +7044,12 @@
             }
         },
         "@babel/parser": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.26.0"
+                "@babel/types": "^7.29.8"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -6950,71 +7188,65 @@
             }
         },
         "@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.29.7",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.26.2",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-                    "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+                    "version": "7.29.7",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+                    "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
                     "dev": true,
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.25.9",
+                        "@babel/helper-validator-identifier": "^7.29.7",
                         "js-tokens": "^4.0.0",
-                        "picocolors": "^1.0.0"
+                        "picocolors": "^1.1.1"
                     }
                 }
             }
         },
         "@babel/traverse": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/generator": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.25.9",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.8",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.8",
+                "debug": "^4.3.1"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.26.2",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-                    "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+                    "version": "7.29.7",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/code-frame/-/code-frame-7.29.7.tgz",
+                    "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
                     "dev": true,
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.25.9",
+                        "@babel/helper-validator-identifier": "^7.29.7",
                         "js-tokens": "^4.0.0",
-                        "picocolors": "^1.0.0"
+                        "picocolors": "^1.1.1"
                     }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
                 }
             }
         },
         "@babel/types": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "version": "7.29.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             }
         },
         "@bcoe/v8-coverage": {
@@ -7060,9 +7292,9 @@
                     }
                 },
                 "js-yaml": {
-                    "version": "3.14.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "version": "3.15.1",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
                     "dev": true,
                     "requires": {
                         "argparse": "^1.0.7",
@@ -7116,9 +7348,9 @@
                     }
                 },
                 "js-yaml": {
-                    "version": "3.14.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "version": "3.15.1",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
                     "dev": true,
                     "requires": {
                         "argparse": "^1.0.7",
@@ -7332,38 +7564,41 @@
             }
         },
         "@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.13",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "requires": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true
         },
-        "@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-            "dev": true
-        },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -7561,9 +7796,9 @@
             }
         },
         "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -7799,10 +8034,16 @@
                 }
             }
         },
+        "baseline-browser-mapping": {
+            "version": "2.11.19",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+            "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
+            "dev": true
+        },
         "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.18",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7824,15 +8065,16 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.24.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-            "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+            "version": "4.28.8",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/browserslist/-/browserslist-4.28.8.tgz",
+            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001669",
-                "electron-to-chromium": "^1.5.41",
-                "node-releases": "^2.0.18",
-                "update-browserslist-db": "^1.1.1"
+                "baseline-browser-mapping": "^2.11.12",
+                "caniuse-lite": "^1.0.30001809",
+                "electron-to-chromium": "^1.5.402",
+                "node-releases": "^2.0.53",
+                "update-browserslist-db": "^1.3.0"
             }
         },
         "bser": {
@@ -7867,6 +8109,16 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -7880,9 +8132,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001677",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-            "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+            "version": "1.0.30001810",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true
         },
         "capture-exit": {
@@ -8041,9 +8293,9 @@
             "dev": true
         },
         "cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
@@ -8187,10 +8439,21 @@
                 "glob": "^7.1.6"
             }
         },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
         "electron-to-chromium": {
-            "version": "1.5.50",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
-            "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
+            "version": "1.5.415",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+            "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
             "dev": true
         },
         "emittery": {
@@ -8233,9 +8496,42 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true
+        },
+        "es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            }
+        },
         "escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true
         },
@@ -8323,9 +8619,9 @@
                     }
                 },
                 "js-yaml": {
-                    "version": "3.14.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "version": "3.15.1",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
                     "dev": true,
                     "requires": {
                         "argparse": "^1.0.7",
@@ -8618,9 +8914,9 @@
             "dev": true
         },
         "fast-uri": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+            "version": "3.1.6",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "dev": true
         },
         "fb-watchman": {
@@ -8672,9 +8968,9 @@
             }
         },
         "flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "version": "3.4.4",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true
         },
         "for-in": {
@@ -8684,14 +8980,16 @@
             "dev": true
         },
         "form-data": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
-            "integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
+            "version": "3.0.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/form-data/-/form-data-3.0.5.tgz",
+            "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
             "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             }
         },
         "fragment-cache": {
@@ -8739,11 +9037,39 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
+        "get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
         "get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
         },
         "get-stream": {
             "version": "5.2.0",
@@ -8791,6 +9117,12 @@
                 "type-fest": "^0.20.2"
             }
         },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true
+        },
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -8809,6 +9141,21 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true
+        },
+        "has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.3"
+            }
         },
         "has-value": {
             "version": "1.0.0",
@@ -8863,9 +9210,9 @@
             }
         },
         "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "requires": {
                 "function-bind": "^1.1.2"
@@ -9641,9 +9988,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.3.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "requires": {
                 "argparse": "^2.0.1"
             }
@@ -9780,9 +10127,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true
         },
         "lodash.clonedeep": {
@@ -9803,7 +10150,7 @@
         },
         "lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "requires": {
@@ -9843,6 +10190,12 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9881,9 +10234,9 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -9963,9 +10316,9 @@
             }
         },
         "node-releases": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "version": "2.0.53",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/node-releases/-/node-releases-2.0.53.tgz",
+            "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
             "dev": true
         },
         "normalize-package-data": {
@@ -10198,9 +10551,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true
         },
         "pirates": {
@@ -10522,9 +10875,9 @@
                     }
                 },
                 "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "version": "6.0.6",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/cross-spawn/-/cross-spawn-6.0.6.tgz",
+                    "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
                     "dev": true,
                     "requires": {
                         "nice-try": "^1.0.4",
@@ -11145,9 +11498,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.17.1",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-                    "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+                    "version": "8.20.0",
+                    "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ajv/-/ajv-8.20.0.tgz",
+                    "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
@@ -11301,9 +11654,9 @@
             }
         },
         "undici": {
-            "version": "5.28.4",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+            "version": "5.29.0",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
             "requires": {
                 "@fastify/busboy": "^2.0.0"
             }
@@ -11381,13 +11734,13 @@
             }
         },
         "update-browserslist-db": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-            "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+            "version": "1.3.1",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "dev": true,
             "requires": {
                 "escalade": "^3.2.0",
-                "picocolors": "^1.1.0"
+                "picocolors": "^1.1.1"
             }
         },
         "uri-js": {
@@ -11572,9 +11925,9 @@
             }
         },
         "ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "7.5.13",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "dev": true,
             "requires": {}
         },
@@ -11598,7 +11951,7 @@
         },
         "yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -467,7 +467,7 @@
     },
     "node_modules/asciidoctor-opal-runtime/node_modules/brace-expansion": {
       "version": "1.1.18",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
@@ -496,7 +496,7 @@
     },
     "node_modules/asciidoctor-opal-runtime/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -542,7 +542,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
@@ -609,7 +609,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
@@ -677,7 +677,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind/-/call-bind-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
@@ -696,7 +696,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
@@ -710,7 +710,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
@@ -840,7 +840,7 @@
     },
     "node_modules/convict": {
       "version": "6.2.5",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/convict/-/convict-6.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.5.tgz",
       "integrity": "sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -936,7 +936,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
@@ -1015,7 +1015,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
@@ -1048,7 +1048,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -1067,7 +1067,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
@@ -1168,7 +1168,7 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
@@ -1189,7 +1189,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/for-each/-/for-each-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
@@ -1220,7 +1220,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
@@ -1245,7 +1245,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
@@ -1292,7 +1292,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -1305,7 +1305,7 @@
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/handlebars/-/handlebars-4.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
@@ -1336,7 +1336,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
@@ -1349,7 +1349,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
@@ -1362,7 +1362,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
@@ -1560,7 +1560,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
@@ -1603,7 +1603,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
@@ -1619,7 +1619,7 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
@@ -1666,7 +1666,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
@@ -1691,7 +1691,7 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
@@ -1716,7 +1716,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
@@ -1748,7 +1748,7 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -1806,7 +1806,7 @@
     },
     "node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
@@ -1886,7 +1886,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
@@ -1962,7 +1962,7 @@
     },
     "node_modules/picomatch": {
       "version": "4.0.7",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
@@ -2105,7 +2105,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
@@ -2149,7 +2149,7 @@
     },
     "node_modules/qs": {
       "version": "6.15.3",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/qs/-/qs-6.15.3.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2323,7 +2323,7 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
@@ -2341,7 +2341,7 @@
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/sha.js/-/sha.js-2.4.12.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
       "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dev": true,
       "license": "(MIT AND BSD-3-Clause)",
@@ -2362,7 +2362,7 @@
     },
     "node_modules/sha.js/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
@@ -2389,7 +2389,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
@@ -2409,7 +2409,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
@@ -2426,7 +2426,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
@@ -2445,7 +2445,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
@@ -2628,7 +2628,7 @@
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/to-buffer/-/to-buffer-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
       "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
       "dev": true,
       "license": "MIT",
@@ -2643,7 +2643,7 @@
     },
     "node_modules/to-buffer/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
@@ -2682,7 +2682,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
@@ -2771,7 +2771,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
-      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
       "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -466,10 +466,11 @@
       }
     },
     "node_modules/asciidoctor-opal-runtime/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -494,10 +495,11 @@
       }
     },
     "node_modules/asciidoctor-opal-runtime/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -536,6 +538,22 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -590,10 +608,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.4",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -657,16 +676,47 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.9",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -789,10 +839,11 @@
       "dev": true
     },
     "node_modules/convict": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
-      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "version": "6.2.5",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/convict/-/convict-6.2.5.tgz",
+      "integrity": "sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "yargs-parser": "^20.2.7"
@@ -885,9 +936,10 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -961,6 +1013,21 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -980,13 +1047,11 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -996,6 +1061,19 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -1089,9 +1167,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -1099,6 +1177,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1106,6 +1185,22 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fs.realpath": {
@@ -1124,22 +1219,42 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1176,22 +1291,24 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -1219,9 +1336,10 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -1229,11 +1347,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1241,11 +1360,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1435,6 +1558,19 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1464,6 +1600,29 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isomorphic-git": {
       "version": "1.25.10",
@@ -1506,10 +1665,11 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1530,10 +1690,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -1552,6 +1713,16 @@
       "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.9.0.tgz",
       "integrity": "sha512-Be5vFuc8NAheOIjviCRms3ZqFFBlzns3u9DXpPSZvALetgnydAN0poV71pVLFn0keYy/s4VblMMkqewTLe+KPg==",
       "dev": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1576,10 +1747,11 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1633,10 +1805,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1712,10 +1885,11 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1787,10 +1961,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.7",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1928,6 +2103,16 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -1963,12 +2148,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.3",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2136,9 +2323,10 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -2152,17 +2340,46 @@
       }
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sha.js/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/should-proxy": {
       "version": "1.0.4",
@@ -2171,15 +2388,73 @@
       "dev": true
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2351,6 +2626,42 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2368,6 +2679,21 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -2441,6 +2767,28 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://inditex.jfrog.io/artifactory/api/npm/node-public/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wordwrap": {


### PR DESCRIPTION
## What

Regenerate the two **CI/build-only** npm lockfiles with `npm audit fix --package-lock-only` — semver **in-range** only (patch/minor, no breaking major bumps, no direct-dependency range changes). **Only the lockfiles change; neither `package.json` is touched**, so there is no application-behavior or build-behavior change.

| Lockfile | Role | Closed | Residual (left untouched) |
|---|---|---|---|
| `docs/package-lock.json` | Antora docs tooling | sha.js / convict / handlebars criticals, qs, lodash, minimatch, brace-expansion, picomatch, follow-redirects | **7** (1 high `js-yaml` merge-key blocked behind a parent pin, 6 moderate) — need breaking bumps |
| `.github/actions/config-resolver/package-lock.json` | CI config-resolver action | ws, form-data, fast-uri, flatted, lodash, minimatch, picomatch, cross-spawn, undici (→5.29) | **25** (undici / jest chain) — need a breaking `--force` (jest 26→30, undici 5→6/7) |

## Why this is safe / low-risk

- **No `package.json` change** — direct-dependency ranges are unchanged; this is a pure lockfile regeneration equivalent to what `npm ci` would resolve within the existing ranges.
- **Neither lockfile ships in the Java artifact.** Both are build/CI tooling only, never on the runtime classpath.
- `--package-lock-only` (no `node_modules` install) is the correct mode for these repos, which don't vendor `node_modules`.

## Deliberately out of scope

- The breaking `--force` migrations (jest/undici/uuid major bumps) — behavior-affecting, left for a separate deliberate change.
- The docs residual `js-yaml` high — blocked behind a parent pin; needs a direct-dep move.
- Runtime Maven dependency alerts (`code/pom.xml`: postgresql, spring-core) — shipped runtime, out of scope here.

---
🔒 Independent product-owned dependency hygiene. Separate from the workflow-permissions hardening PR. Kept **draft** pending review.